### PR TITLE
Add complete Kubernetes demo manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,241 @@
-# kubernetes-practice
+# Kubernetes Learning Guide
+
+Welcome! This guide is meant to give you a structured path for learning Kubernetes (K8s) after you have a local cluster running (for example with Docker Desktop, minikube, or kind). It combines conceptual explanations, hands-on milestones, and suggestions for further exploration.
+
+If you want to dive straight into a practical walkthrough, the repository now includes a [hands-on demo](demo/README.md) with ready-to-apply manifests that exercise Deployments, Services, ConfigMaps, Secrets, Jobs, CronJobs, HPAs, and StatefulSets. You can apply everything with `kubectl apply -k demo/manifests`.
+
+---
+
+## 1. Core Concepts
+
+### 1.1 What is Kubernetes?
+Kubernetes is an open-source orchestration platform that automates the deployment, scaling, and management of containerized applications. It abstracts the underlying infrastructure so you can describe your system declaratively (desired state) and let Kubernetes keep it running.
+
+### 1.2 Kubernetes Architecture Overview
+- **Control Plane** – Maintains cluster state.
+  - `kube-apiserver`: REST API and front door to the cluster.
+  - `etcd`: Highly available key-value store for cluster state.
+  - `kube-scheduler`: Assigns Pods to Nodes.
+  - `kube-controller-manager`: Runs controllers that reconcile desired vs. current state.
+  - `cloud-controller-manager`: Integrates with cloud providers (optional for local setups).
+- **Worker Nodes** – Run your workloads.
+  - `kubelet`: Agent ensuring containers described in Pod specs are running.
+  - `kube-proxy`: Handles networking, implementing Services.
+  - `container runtime`: Runs containers (containerd, Docker, etc.).
+
+### 1.3 Kubernetes API Primitives
+- **Namespace** – Logical partitioning of cluster resources.
+- **Pod** – Smallest deployable unit; one or more containers sharing storage/network.
+- **ReplicaSet** – Ensures a specified number of Pod replicas are running.
+- **Deployment** – Manages ReplicaSets and allows declarative updates.
+- **DaemonSet** – Runs a Pod copy on every (or selected) node.
+- **StatefulSet** – Manages stateful applications with stable network identities and persistent storage.
+- **Job/CronJob** – Run finite or scheduled tasks.
+- **Service** – Stable networking abstraction exposing Pods.
+- **Ingress** – HTTP(S) routing into cluster.
+- **ConfigMap/Secret** – Inject configuration or sensitive data.
+- **PersistentVolume / PersistentVolumeClaim** – Abstract storage.
+
+---
+
+## 2. Getting Hands-On
+
+### 2.1 Verify Your Cluster
+1. `kubectl version --short`
+2. `kubectl cluster-info`
+3. `kubectl get nodes`
+
+### 2.2 First Deployment
+1. Create a Namespace: `kubectl create namespace demo`
+2. Deploy a simple app:
+   ```bash
+   kubectl create deployment hello --image=nginxdemos/hello -n demo
+   kubectl expose deployment hello --type=ClusterIP --port=80 --target-port=80 -n demo
+   ```
+3. Explore resources: `kubectl get all -n demo`
+4. Port-forward to test locally: `kubectl port-forward svc/hello 8080:80 -n demo`
+
+### 2.3 Declarative Manifests
+1. Write YAML for the Deployment and Service.
+2. Apply it: `kubectl apply -f deployment.yaml`
+3. Update image/tag and re-apply to practice rolling updates.
+
+### 2.4 Observability Basics
+- `kubectl describe <resource>` for detailed state.
+- `kubectl logs <pod>` for application logs.
+- Use `kubectl top nodes/pods` with Metrics Server installed.
+
+---
+
+## 3. Understanding Networking
+
+### 3.1 Pod Networking
+- Pods get an IP address from the cluster network; they can reach each other directly.
+- The CNI (Container Network Interface) plugin (e.g., Flannel, Calico) sets up networking.
+
+### 3.2 Services
+- **ClusterIP** – Internal-only stable IP.
+- **NodePort** – Exposes service on each node IP at a static port.
+- **LoadBalancer** – Provisions external load balancers (depends on environment).
+- **Headless Service** – Used for direct Pod access (e.g., stateful apps).
+
+### 3.3 Ingress Controllers
+- Provide HTTP/HTTPS routing based on host/path rules.
+- Popular controllers: NGINX Ingress Controller, Traefik, Istio ingress gateway.
+
+---
+
+## 4. Configuring Applications
+
+### 4.1 ConfigMaps and Secrets
+- Store configuration separate from images.
+- Mount as environment variables or files.
+- Secrets are base64-encoded; use dedicated secret managers for production.
+
+### 4.2 Environment-Specific Configuration
+- Use multiple overlays (e.g., with [Kustomize](https://kustomize.io/) or Helm charts) to manage different environments.
+
+### 4.3 Resource Requests & Limits
+- Define CPU/memory requests (minimum guaranteed) and limits (maximum allowed).
+- Proper sizing enables effective scheduling and cluster stability.
+
+---
+
+## 5. Storage
+
+### 5.1 Volumes
+- **emptyDir** – Ephemeral storage tied to Pod lifecycle.
+- **hostPath** – Direct mount from node filesystem (not portable).
+- **PersistentVolume** – Cluster-level storage resource.
+
+### 5.2 PersistentVolumeClaims (PVC)
+- Pods request storage via PVCs; Kubernetes binds to a matching PV.
+
+### 5.3 StorageClasses & Dynamic Provisioning
+- StorageClasses define provisioners and parameters.
+- With dynamic provisioning, PVCs automatically create PVs.
+
+### 5.4 Stateful Applications
+- Use StatefulSets + PVC templates.
+- Consider backup/restore strategies.
+
+---
+
+## 6. Scaling and Updates
+
+### 6.1 Horizontal Pod Autoscaler (HPA)
+- Scales Pods based on metrics (CPU, custom metrics).
+- `kubectl autoscale deployment hello --min=2 --max=5 --cpu-percent=60`
+
+### 6.2 Vertical Pod Autoscaler (VPA)
+- Suggests or automatically adjusts resource requests/limits.
+
+### 6.3 Cluster Autoscaler
+- Adds/removes nodes (in cloud environments).
+
+### 6.4 Rolling Updates & Rollbacks
+- `kubectl rollout status deployment/hello`
+- `kubectl rollout history deployment/hello`
+- `kubectl rollout undo deployment/hello`
+
+---
+
+## 7. Security Fundamentals
+
+### 7.1 RBAC (Role-Based Access Control)
+- **Role/ClusterRole** – Define permissions.
+- **RoleBinding/ClusterRoleBinding** – Attach roles to users/groups/service accounts.
+
+### 7.2 Service Accounts
+- Identity for Pods; used for API access.
+
+### 7.3 Network Policies
+- Define allowed ingress/egress traffic between Pods.
+
+### 7.4 Pod Security
+- Pod Security Standards (Baseline, Restricted) or Admission Controllers.
+- Use securityContext: run as non-root, drop capabilities, read-only root filesystem.
+
+### 7.5 Secret Management
+- Integrate with external secret stores (e.g., HashiCorp Vault, AWS Secrets Manager).
+
+---
+
+## 8. Observability & Troubleshooting
+
+### 8.1 Logging
+- Centralize logs with Fluentd, Fluent Bit, or Logstash.
+- Use EFK (Elasticsearch, Fluentd, Kibana) or Loki/Grafana stacks.
+
+### 8.2 Metrics & Monitoring
+- Prometheus + Alertmanager for metrics and alerts.
+- Grafana for visualization.
+- Kubernetes Dashboard (with caution for production).
+
+### 8.3 Tracing
+- Distributed tracing with Jaeger or Zipkin; integrate via service mesh or instrumentation.
+
+### 8.4 Debugging Tips
+- `kubectl describe` and `kubectl logs`.
+- `kubectl exec -it <pod> -- /bin/sh` for interactive debugging (if permitted).
+- Use ephemeral containers (`kubectl debug`) for troubleshooting.
+
+---
+
+## 9. Advanced Topics
+
+### 9.1 Helm
+- Package manager for Kubernetes; templating & release management.
+- Explore `helm create`, `helm install`, `helm upgrade`.
+
+### 9.2 Kustomize
+- Overlay-based configuration management built into `kubectl`.
+
+### 9.3 Operators & CRDs
+- Extend Kubernetes with Custom Resource Definitions and controllers (Operators).
+
+### 9.4 Service Mesh
+- Istio, Linkerd, Consul for advanced traffic management, security, observability.
+
+### 9.5 GitOps
+- Manage deployments via Git (e.g., Argo CD, Flux).
+
+### 9.6 Multi-Cluster & Federation
+- Manage multiple clusters, global services, failover.
+
+---
+
+## 10. Practice Roadmap
+
+1. **Week 1 – Basics**: Pods, Deployments, Services, Namespaces.
+2. **Week 2 – Configuration & Storage**: ConfigMaps, Secrets, PVCs.
+3. **Week 3 – Scaling & Updates**: HPA, rollouts, resource tuning.
+4. **Week 4 – Security & Observability**: RBAC, Network Policies, monitoring stack.
+5. **Week 5 – Advanced**: Helm, Operators, GitOps.
+6. **Capstone**: Deploy a multi-tier app with CI/CD pipeline and monitoring.
+
+Track progress by keeping manifests in version control and writing post-mortems for any issues you encounter.
+
+---
+
+## 11. Helpful Tools & Resources
+
+- **Documentation**: [kubernetes.io/docs](https://kubernetes.io/docs/)
+- **Kubernetes the Hard Way** (Kelsey Hightower)
+- **Playgrounds**: [Katacoda (O'Reilly)](https://www.oreilly.com/online-learning/), [killercoda.com](https://killercoda.com/)
+- **Courses**: CNCF Certified Kubernetes Administrator (CKA) curriculum, Kubernetes By Example.
+- **Books**: *Kubernetes Up & Running*, *The Kubernetes Book*.
+- **CLI Enhancements**: `kubectx`, `kubens`, `k9s`, `stern`.
+
+---
+
+## 12. Next Steps
+
+- Automate manifest management (Helm/Kustomize).
+- Experiment with Stateful applications and storage classes.
+- Explore CI/CD pipelines that deploy to your cluster.
+- Set up monitoring and alerts.
+- Contribute to open-source Kubernetes ecosystem projects.
+
+Happy learning! Keep practicing with real workloads and gradually adopt production-grade patterns as your confidence grows.
+

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,112 @@
+# Kubernetes Hands-On Demo
+
+This demo gives you an end-to-end walkthrough for deploying and operating a simple microservice stack on a local Kubernetes cluster (Docker Desktop, minikube, or kind). It complements the top-level learning guide by providing concrete manifests and commands you can run immediately.
+
+## Demo Goals
+
+* Deploy an application stack composed of a web API, a backing Redis cache, and supporting jobs.
+* Showcase core Kubernetes objects: Namespace, Deployment, Service, ConfigMap, Secret, HorizontalPodAutoscaler, Job, CronJob, and StatefulSet.
+* Demonstrate configuration management, health probes, resource management, networking, and persistent storage.
+
+## Prerequisites
+
+* A working local Kubernetes cluster (`kubectl cluster-info` should succeed).
+* `kubectl` v1.23+.
+* (Optional) Metrics Server installed for the HorizontalPodAutoscaler. On Docker Desktop it is included by default; for minikube run `minikube addons enable metrics-server`.
+
+## Directory Structure
+
+```text
+demo/
+├── README.md                # This file
+└── manifests/
+    ├── 00-namespace.yaml
+    ├── 01-configmap.yaml
+    ├── 02-secret.yaml
+    ├── 03-deployment.yaml
+    ├── 04-service.yaml
+    ├── 05-hpa.yaml
+    ├── 06-job.yaml
+    ├── 07-cronjob.yaml
+    ├── 08-pvc.yaml
+    ├── 09-statefulset.yaml
+    └── kustomization.yaml
+```
+
+## Running the Demo
+
+### 1. Inspect the Manifests
+
+Each manifest is heavily commented. Read through them to understand how the objects map to the concepts in the learning guide.
+
+### 2. Apply Everything with Kustomize
+
+```bash
+kubectl apply -k demo/manifests
+```
+
+This command creates a dedicated namespace (`kube-demo`) and deploys the whole stack.
+
+### 3. Verify the Deployment
+
+```bash
+kubectl get all -n kube-demo
+kubectl get pods -n kube-demo -w
+```
+
+Wait until all Pods transition to `Running` (Deployments) or `Completed` (Job/CronJob).
+
+### 4. Access the Web API
+
+Port-forward the web service to your machine:
+
+```bash
+kubectl port-forward svc/web-service -n kube-demo 8080:8080
+```
+
+Then curl the endpoint:
+
+```bash
+curl http://localhost:8080/
+```
+
+The response includes the message stored in the ConfigMap and the API key sourced from the Secret to illustrate configuration injection.
+
+### 5. Observe Autoscaling
+
+Generate load so the HorizontalPodAutoscaler scales the deployment:
+
+```bash
+kubectl run load-generator \
+  --rm -i --tty \
+  --image=busybox:1.36 \
+  --restart=Never \
+  --namespace kube-demo \
+  -- /bin/sh -c "while true; do wget -q -O- http://web-service:8080; done"
+```
+
+In another terminal, watch the HPA react:
+
+```bash
+kubectl get hpa -n kube-demo -w
+```
+
+### 6. Inspect Jobs and StatefulSet
+
+* View the one-off Job logs: `kubectl logs job/data-migration -n kube-demo`
+* Confirm the CronJob scheduled run: `kubectl get cronjob -n kube-demo`
+* Check Redis persistence: `kubectl exec statefulset/redis -n kube-demo -- redis-cli INFO persistence`
+
+### 7. Clean Up
+
+```bash
+kubectl delete -k demo/manifests
+```
+
+## Troubleshooting Tips
+
+* If Pods stay in `Pending`, run `kubectl describe pod <name> -n kube-demo` to check for resource or PVC issues.
+* For PVC problems in Docker Desktop, ensure the built-in storage class is available via `kubectl get storageclass`.
+* Metrics Server issues? Verify with `kubectl top pods -n kube-demo`. If it fails, install or enable Metrics Server first.
+
+Enjoy experimenting! Try editing the manifests (e.g., change replica counts, tweak environment variables, add probes) and re-run `kubectl apply -k demo/manifests` to see how Kubernetes reconciles the new desired state.

--- a/demo/manifests/00-namespace.yaml
+++ b/demo/manifests/00-namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-demo
+  labels:
+    purpose: learning
+---
+# Namespace scoping keeps demo resources isolated from anything else running
+# in your local cluster. Applying the namespace first ensures the other
+# manifests can reference it by name.

--- a/demo/manifests/01-configmap.yaml
+++ b/demo/manifests/01-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-config
+  namespace: kube-demo
+data:
+  MESSAGE: "Welcome to the Kubernetes hands-on demo!"
+  REDIS_HOST: "redis-0.redis"
+  REDIS_PORT: "6379"
+---
+# ConfigMaps store non-sensitive configuration for our application. The
+# Deployment consumes these values as environment variables.

--- a/demo/manifests/02-secret.yaml
+++ b/demo/manifests/02-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: web-secret
+  namespace: kube-demo
+type: Opaque
+stringData:
+  API_KEY: "demo-api-key-12345"
+---
+# Secrets hold sensitive data. Using stringData lets you write plaintext in
+# version control; Kubernetes converts it to base64 in the stored Secret.

--- a/demo/manifests/03-deployment.yaml
+++ b/demo/manifests/03-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: kube-demo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: hello-app
+          image: ghcr.io/paulbouwer/hello-kubernetes:1.10
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MESSAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: web-config
+                  key: MESSAGE
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: web-config
+                  key: REDIS_HOST
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: web-config
+                  key: REDIS_PORT
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: web-secret
+                  key: API_KEY
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 20
+---
+# The Deployment demonstrates declarative workloads. It consumes configuration
+# via ConfigMaps and Secrets, requests/limits resources, and defines health
+# probes so Kubernetes can automatically restart unhealthy Pods.

--- a/demo/manifests/04-service.yaml
+++ b/demo/manifests/04-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-service
+  namespace: kube-demo
+  labels:
+    app: web
+spec:
+  type: ClusterIP
+  selector:
+    app: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+# The Service gives the Pods a stable virtual IP and DNS name. Other objects in
+# the namespace can talk to `web-service` regardless of Pod churn.

--- a/demo/manifests/05-hpa.yaml
+++ b/demo/manifests/05-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web
+  namespace: kube-demo
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+---
+# The HPA watches CPU usage and adjusts the Deployment replica count within the
+# defined bounds. Requires Metrics Server to provide Pod metrics.

--- a/demo/manifests/06-job.yaml
+++ b/demo/manifests/06-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-migration
+  namespace: kube-demo
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        job: data-migration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: bitnami/kubectl:1.30.3
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Pretending to run a database migration";
+              echo "API key available to jobs: $API_KEY";
+              sleep 2;
+              echo "Done!"
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: web-secret
+                  key: API_KEY
+---
+# The Job runs a one-off task to illustrate batch workloads. We use a short TTL
+# so Kubernetes garbage-collects the completed Pod after a few minutes.

--- a/demo/manifests/07-cronjob.yaml
+++ b/demo/manifests/07-cronjob.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cache-warmup
+  namespace: kube-demo
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: warmup
+              image: curlimages/curl:8.8.0
+              args:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Calling the web API to warm the cache";
+                  curl -fsS http://web-service:8080/ > /dev/null;
+                  echo "Finished cache warmup run"
+---
+# CronJobs schedule recurring tasks. This one executes every five minutes to
+# simulate seeding the cache by calling the service.

--- a/demo/manifests/08-pvc.yaml
+++ b/demo/manifests/08-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+  namespace: kube-demo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+# Docker Desktop, kind, and minikube all ship with a default StorageClass.
+# Because we omit storageClassName entirely, the cluster's default class will
+# provision backing storage for this claim automatically.

--- a/demo/manifests/09-statefulset.yaml
+++ b/demo/manifests/09-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: kube-demo
+  labels:
+    app: redis
+spec:
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: kube-demo
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          args:
+            - "--save"
+            - "60"
+            - "1"
+          volumeMounts:
+            - name: redis-storage
+              mountPath: /data
+      volumes:
+        - name: redis-storage
+          persistentVolumeClaim:
+            claimName: redis-data
+---
+# The headless Service gives each Redis Pod a stable DNS identity
+# (<pod-name>.redis.kube-demo.svc). The StatefulSet consumes the PersistentVolume
+# Claim created separately to persist data across Pod restarts.

--- a/demo/manifests/kustomization.yaml
+++ b/demo/manifests/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - 00-namespace.yaml
+  - 01-configmap.yaml
+  - 02-secret.yaml
+  - 08-pvc.yaml
+  - 03-deployment.yaml
+  - 04-service.yaml
+  - 05-hpa.yaml
+  - 06-job.yaml
+  - 07-cronjob.yaml
+  - 09-statefulset.yaml


### PR DESCRIPTION
## Summary
- add a hands-on demo directory with instructions for deploying a sample stack on a local cluster
- supply kustomize-ready manifests covering namespace, config, secrets, workload, autoscaling, jobs, storage, and stateful services
- link the main learning guide to the new demo for quick practical experimentation

## Testing
- not run (documentation and manifest change)


------
https://chatgpt.com/codex/tasks/task_e_68e30f3b036c83309fa4b86f3f50d689